### PR TITLE
feat(exchange): implementar endpoints REST para gestionar intercambios

### DIFF
--- a/src/main/java/com/devops/backend/rewear/controllers/ExchangeController.java
+++ b/src/main/java/com/devops/backend/rewear/controllers/ExchangeController.java
@@ -1,0 +1,51 @@
+package com.devops.backend.rewear.controllers;
+
+import com.devops.backend.rewear.dtos.request.SaveExchange;
+import com.devops.backend.rewear.dtos.response.GetExchange;
+import com.devops.backend.rewear.services.ExchangeService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/exchanges")
+public class ExchangeController {
+    private final ExchangeService exchangeService;
+
+    public ExchangeController(ExchangeService exchangeService) {
+        this.exchangeService = exchangeService;
+    }
+
+    @PreAuthorize("hasRole('ADMIN')")
+    @GetMapping("/all")
+    public ResponseEntity<List<GetExchange>> getAllExchanges(){
+        return ResponseEntity.ok(exchangeService.getAllExchanges());
+    }
+
+    @PostMapping
+    ResponseEntity<GetExchange> saveExchange(SaveExchange saveExchange){
+        return ResponseEntity.ok().body(exchangeService.save(saveExchange));
+    }
+
+    @PatchMapping("/{id}/accept")
+    ResponseEntity<GetExchange> acceptExchange(@PathVariable Long id){
+        return ResponseEntity.ok(exchangeService.acceptExchange(id));
+    }
+
+    @PatchMapping("/{id}/confirm")
+    ResponseEntity<GetExchange> confirmExchange(@PathVariable Long id){
+        return ResponseEntity.ok(exchangeService.confirmExchange(id));
+    }
+
+    @PatchMapping("/{id}/reject")
+    ResponseEntity<GetExchange> rejectExchange(@PathVariable Long id){
+        return ResponseEntity.ok(exchangeService.rejectExchange(id));
+    }
+
+    @PatchMapping("/{id}/cancel")
+    ResponseEntity<GetExchange> cancelExchange(@PathVariable Long id){
+        return ResponseEntity.ok(exchangeService.cancelExchange(id));
+    }
+}

--- a/src/main/java/com/devops/backend/rewear/dtos/request/SaveExchange.java
+++ b/src/main/java/com/devops/backend/rewear/dtos/request/SaveExchange.java
@@ -1,0 +1,13 @@
+package com.devops.backend.rewear.dtos.request;
+
+import jakarta.validation.constraints.NotNull;
+
+import java.io.Serializable;
+
+public record SaveExchange(
+        @NotNull(message = "debe solicitar una prenda en un intercambio")
+        Long requestedWearId,
+        @NotNull(message = "debe ofrecer una prenda en un intercambio")
+        Long offeredWearId
+) implements Serializable {
+}

--- a/src/main/java/com/devops/backend/rewear/dtos/response/GetExchange.java
+++ b/src/main/java/com/devops/backend/rewear/dtos/response/GetExchange.java
@@ -1,0 +1,20 @@
+package com.devops.backend.rewear.dtos.response;
+
+import com.devops.backend.rewear.entities.enums.ExchangeStatus;
+
+import java.io.Serializable;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record GetExchange(
+    Long id,
+    Long requesterId,
+    Long ownerId,
+    Long offeredWearId,
+    Long requestedWearId,
+    ExchangeStatus status,
+    LocalDateTime createdAt,
+    LocalDateTime updatedAt,
+    List<GetReview> reviews
+) implements Serializable {
+}

--- a/src/main/java/com/devops/backend/rewear/entities/Exchange.java
+++ b/src/main/java/com/devops/backend/rewear/entities/Exchange.java
@@ -1,0 +1,66 @@
+package com.devops.backend.rewear.entities;
+
+import com.devops.backend.rewear.entities.enums.ExchangeStatus;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "exchanges")
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class Exchange {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // Usuario que solicita el intercambio
+    @NotNull(message = "El solicitante no puede ser nulo")
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "requester_id", nullable = false)
+    private User requester;
+
+    // Usuario dueño de la prenda solicitada
+    @NotNull(message = "El dueño no puede ser nulo")
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "owner_id", nullable = false)
+    private User owner;
+
+    // Prenda ofrecida por el solicitante
+    @NotNull(message = "Debe ofrecer una prenda para el intercambio")
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "offered_wear_id", nullable = false)
+    private Wear offeredWear;
+
+    // Prenda que el solicitante desea obtener
+    @NotNull(message = "Debe seleccionar una prenda solicitada")
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "requested_wear_id", nullable = false)
+    private Wear requestedWear;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private ExchangeStatus status = ExchangeStatus.PENDING;
+
+    @Column(nullable = false)
+    private boolean requesterConfirmed = false;
+
+    @Column(nullable = false)
+    private boolean ownerConfirmed = false;
+
+    @CreationTimestamp
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    private LocalDateTime updatedAt;
+
+}

--- a/src/main/java/com/devops/backend/rewear/entities/User.java
+++ b/src/main/java/com/devops/backend/rewear/entities/User.java
@@ -127,6 +127,15 @@ public class User implements UserDetails {
     @OneToMany(mappedBy = "owner", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Wear> wears = new ArrayList<>();
 
+    //intercambios solicitados por el usuario
+    @OneToMany(mappedBy = "requester", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    private List<Exchange> requestedExchanges = new ArrayList<>();
+
+    //intercambios solicitados al usuario
+    @OneToMany(mappedBy = "owner", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    private List<Exchange> ownedExchanges = new ArrayList<>();
+
+
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
         // Evita NullPointerException si el usuario no tiene rol asignado

--- a/src/main/java/com/devops/backend/rewear/entities/enums/ExchangeStatus.java
+++ b/src/main/java/com/devops/backend/rewear/entities/enums/ExchangeStatus.java
@@ -1,0 +1,5 @@
+package com.devops.backend.rewear.entities.enums;
+
+public enum ExchangeStatus {
+    PENDING, ACCEPTED, REJECTED, CANCELLED, COMPLETED
+}

--- a/src/main/java/com/devops/backend/rewear/exceptions/ExchangeNotFoundException.java
+++ b/src/main/java/com/devops/backend/rewear/exceptions/ExchangeNotFoundException.java
@@ -1,0 +1,7 @@
+package com.devops.backend.rewear.exceptions;
+
+public class ExchangeNotFoundException extends RuntimeException {
+    public ExchangeNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/devops/backend/rewear/exceptions/InvalidExchangeException.java
+++ b/src/main/java/com/devops/backend/rewear/exceptions/InvalidExchangeException.java
@@ -1,0 +1,7 @@
+package com.devops.backend.rewear.exceptions;
+
+public class InvalidExchangeException extends RuntimeException {
+    public InvalidExchangeException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/devops/backend/rewear/mappers/ExchangeMapper.java
+++ b/src/main/java/com/devops/backend/rewear/mappers/ExchangeMapper.java
@@ -1,0 +1,54 @@
+package com.devops.backend.rewear.mappers;
+
+import com.devops.backend.rewear.dtos.request.SaveExchange;
+import com.devops.backend.rewear.dtos.response.GetExchange;
+import com.devops.backend.rewear.entities.Exchange;
+import com.devops.backend.rewear.entities.User;
+import com.devops.backend.rewear.entities.Wear;
+import org.mapstruct.*;
+import java.util.List;
+
+@Mapper(componentModel = "spring")
+public interface ExchangeMapper {
+
+    // ======SaveExchange → Exchange ======
+    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "status", expression = "java(com.devops.backend.rewear.entities.enums.ExchangeStatus.PENDING)")
+    @Mapping(target = "requesterConfirmed", constant = "false")
+    @Mapping(target = "ownerConfirmed", constant = "false")
+    @Mapping(target = "createdAt", ignore = true)
+    @Mapping(target = "updatedAt", ignore = true)
+    @Mapping(target = "requester", ignore = true) // se setea en el servicio
+    @Mapping(target = "owner", ignore = true)     // se setea en el servicio
+    @Mapping(target = "offeredWear", source = "offeredWearId", qualifiedByName = "wearFromId")
+    @Mapping(target = "requestedWear", source = "requestedWearId", qualifiedByName = "wearFromId")
+    Exchange toExchange(SaveExchange dto);
+
+    // ====== Exchange → GetExchange ======
+    @Mapping(target = "requesterId", source = "requester.id")
+    @Mapping(target = "ownerId", source = "owner.id")
+    @Mapping(target = "offeredWearId", source = "offeredWear.id")
+    @Mapping(target = "requestedWearId", source = "requestedWear.id")
+    @Mapping(target = "reviews", ignore = true) // se puede mapear luego
+    GetExchange toGetExchange(Exchange entity);
+
+    List<GetExchange> toGetDtoList(List<Exchange> exchanges);
+
+    // ====== 3️⃣ Helpers ======
+    @Named("wearFromId")
+    default Wear wearFromId(Long id) {
+        if (id == null) return null;
+        Wear wear = new Wear();
+        wear.setId(id);
+        return wear;
+    }
+
+    @Named("userFromId")
+    default User userFromId(Long id) {
+        if (id == null) return null;
+        User user = new User();
+        user.setId(id);
+        return user;
+    }
+}
+

--- a/src/main/java/com/devops/backend/rewear/repositories/ExchangeRepository.java
+++ b/src/main/java/com/devops/backend/rewear/repositories/ExchangeRepository.java
@@ -1,0 +1,7 @@
+package com.devops.backend.rewear.repositories;
+
+import com.devops.backend.rewear.entities.Exchange;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ExchangeRepository extends JpaRepository<Exchange, Long> {
+}

--- a/src/main/java/com/devops/backend/rewear/repositories/UserRepository.java
+++ b/src/main/java/com/devops/backend/rewear/repositories/UserRepository.java
@@ -1,8 +1,6 @@
 package com.devops.backend.rewear.repositories;
 
 import com.devops.backend.rewear.entities.User;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;

--- a/src/main/java/com/devops/backend/rewear/services/ExchangeService.java
+++ b/src/main/java/com/devops/backend/rewear/services/ExchangeService.java
@@ -1,0 +1,20 @@
+package com.devops.backend.rewear.services;
+
+import com.devops.backend.rewear.dtos.request.SaveExchange;
+import com.devops.backend.rewear.dtos.response.GetExchange;
+
+import java.util.List;
+
+public interface ExchangeService {
+    GetExchange save(SaveExchange saveExchange);
+
+    GetExchange acceptExchange(Long id);
+
+    GetExchange confirmExchange(Long id);
+
+    GetExchange rejectExchange(Long id);
+
+    GetExchange cancelExchange(Long id);
+
+    List<GetExchange> getAllExchanges();
+}

--- a/src/main/java/com/devops/backend/rewear/services/impl/ExchangeServiceImpl.java
+++ b/src/main/java/com/devops/backend/rewear/services/impl/ExchangeServiceImpl.java
@@ -1,0 +1,159 @@
+package com.devops.backend.rewear.services.impl;
+
+import com.devops.backend.rewear.dtos.request.SaveExchange;
+import com.devops.backend.rewear.dtos.response.GetExchange;
+import com.devops.backend.rewear.entities.Exchange;
+import com.devops.backend.rewear.entities.User;
+import com.devops.backend.rewear.entities.Wear;
+import com.devops.backend.rewear.entities.enums.ExchangeStatus;
+import com.devops.backend.rewear.entities.enums.WearStatus;
+import com.devops.backend.rewear.exceptions.ExchangeNotFoundException;
+import com.devops.backend.rewear.exceptions.InvalidExchangeException;
+import com.devops.backend.rewear.exceptions.WearNotFoundException;
+import com.devops.backend.rewear.mappers.ExchangeMapper;
+import com.devops.backend.rewear.repositories.ExchangeRepository;
+import com.devops.backend.rewear.repositories.UserRepository;
+import com.devops.backend.rewear.repositories.WearRepository;
+import com.devops.backend.rewear.services.ExchangeService;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class ExchangeServiceImpl implements ExchangeService {
+    private final ExchangeRepository exchangeRepository;
+    private final UserRepository userRepository;
+    private final CurrentUserService currentUserService;
+    private final WearRepository wearRepository;
+    private final ExchangeMapper exchangeMapper;
+
+    public ExchangeServiceImpl(ExchangeRepository exchangeRepository, UserRepository userRepository, CurrentUserService currentUserService, WearRepository wearRepository, ExchangeMapper exchangeMapper) {
+        this.exchangeRepository = exchangeRepository;
+        this.userRepository = userRepository;
+        this.currentUserService = currentUserService;
+        this.wearRepository = wearRepository;
+        this.exchangeMapper = exchangeMapper;
+    }
+
+    @Override
+    @Transactional
+    public GetExchange save(SaveExchange saveExchange) {
+        Long requesterId = currentUserService.getAuthenticatedUser().getId();
+
+        // 1. Obtener la prenda ofrecida (debe ser del usuario autenticado)
+        Wear offeredWear = wearRepository.findById(saveExchange.offeredWearId())
+                .orElseThrow(() -> new WearNotFoundException("La prenda ofrecida no existe"));
+        if (!offeredWear.getOwner().getId().equals(requesterId)) {
+            throw new InvalidExchangeException("No puedes ofrecer una prenda que no te pertenece");
+        }
+
+        // 2. Obtener la prenda solicitada (debe ser de otro usuario)
+        Wear requestedWear = wearRepository.findById(saveExchange.requestedWearId())
+                .orElseThrow(() -> new WearNotFoundException("La prenda solicitada no existe"));
+        if (requestedWear.getOwner().getId().equals(requesterId)) {
+            throw new InvalidExchangeException("No puedes solicitar una de tus propias prendas");
+        }
+
+        //3. Crear el intercambio
+        Exchange exchange = Exchange.builder()
+                .requester(userRepository.getReferenceById(requesterId))
+                .owner(requestedWear.getOwner()) //el owner el el propietario de la prenda que se solicita
+                .offeredWear(offeredWear)
+                .requestedWear(requestedWear)
+                .status(ExchangeStatus.PENDING)
+                .build();
+
+        Exchange saved = exchangeRepository.save(exchange);
+
+        return exchangeMapper.toGetExchange(saved);
+    }
+
+    @Override
+    @Transactional
+    public GetExchange acceptExchange(Long id) {
+        User user = currentUserService.getAuthenticatedUser();
+        Exchange exchange = exchangeRepository.findById(id)
+                .orElseThrow(() -> new ExchangeNotFoundException("Error al cambiar el estado del intercambio, no existe en BDD"));
+        if(!exchange.getStatus().equals(ExchangeStatus.PENDING)) {
+            throw new InvalidExchangeException("No puedes acceptar un intercambio que no esta previamente pendiente");
+        }
+        if(!exchange.getOwner().getId().equals(user.getId())) {
+            throw new InvalidExchangeException("Solo puede aceptar este intercambio el dueño de la prenda solicitada");
+        }
+        exchange.setStatus(ExchangeStatus.ACCEPTED);
+        exchange.getOfferedWear().setStatus(WearStatus.RESERVED);
+        exchange.getRequestedWear().setStatus(WearStatus.RESERVED);
+
+        return exchangeMapper.toGetExchange(exchangeRepository.save(exchange));
+    }
+
+    @Override
+    @Transactional
+    public GetExchange confirmExchange(Long id) {
+        User user = currentUserService.getAuthenticatedUser();
+        Exchange exchange = exchangeRepository.findById(id)
+                .orElseThrow(() -> new ExchangeNotFoundException("Error al cambiar el estado del intercambio, no existe en BDD"));
+        if (!exchange.getStatus().equals(ExchangeStatus.ACCEPTED)) {
+            throw new InvalidExchangeException("No puedes confirmar un intercambio que no está previamente aceptado");
+        }
+
+        if (exchange.getOwner().getId().equals(user.getId())) {
+            exchange.setOwnerConfirmed(true); //confirmo el duenio de la prenda
+        } else if (exchange.getRequester().getId().equals(user.getId())) {
+            exchange.setRequesterConfirmed(true);//confirmo el solicitante
+        } else {
+            throw new InvalidExchangeException("Solo pueden confirmar quienes participaron en el intercambio"); //quien realiza la accion no participo en este intercambio
+        }
+
+        if (exchange.isOwnerConfirmed() && exchange.isRequesterConfirmed()) {
+            exchange.setStatus(ExchangeStatus.COMPLETED); //ambos comfirmaron
+        }
+
+        exchange.getOfferedWear().setStatus(WearStatus.EXCHANGED);
+        exchange.getRequestedWear().setStatus(WearStatus.EXCHANGED);
+
+        return exchangeMapper.toGetExchange(exchangeRepository.save(exchange));
+    }
+
+    @Override
+    @Transactional
+    public GetExchange rejectExchange(Long id) {
+        User user = currentUserService.getAuthenticatedUser();
+        Exchange exchange = exchangeRepository.findById(id)
+                .orElseThrow(() -> new ExchangeNotFoundException("Error al cambiar el estado del intercambio, no existe en BDD"));
+        if(!exchange.getStatus().equals(ExchangeStatus.PENDING)) {
+            throw new InvalidExchangeException("No puedes rechazar un intercambio que no esta previamente pendiente");
+        }
+        if(!exchange.getOwner().getId().equals(user.getId())) {
+            throw new InvalidExchangeException("Solo puede rechazar este intercambio el dueño de la prenda solicitada");
+        }
+        exchange.setStatus(ExchangeStatus.REJECTED);
+        return exchangeMapper.toGetExchange(exchangeRepository.save(exchange));
+    }
+
+    @Override
+    @Transactional
+    public GetExchange cancelExchange(Long id) {
+        User user = currentUserService.getAuthenticatedUser();
+        Exchange exchange = exchangeRepository.findById(id)
+                .orElseThrow(() -> new ExchangeNotFoundException("Error al cambiar el estado del intercambio, no existe en BDD"));
+        if(exchange.getStatus().equals(ExchangeStatus.CANCELLED) ||exchange.getStatus().equals(ExchangeStatus.COMPLETED)) {
+            throw new InvalidExchangeException("No puedes cancelar un intercambio que ya ha sido completado o cancelado");
+        }
+        if(!(exchange.getOwner().getId().equals(user.getId()) || exchange.getRequester().getId().equals(user.getId()))) {
+            throw new InvalidExchangeException("Solo puede cancelar este intercambio si participó en el");
+        }
+        exchange.setStatus(ExchangeStatus.CANCELLED);
+        exchange.getRequestedWear().setStatus(WearStatus.AVAILABLE);
+        exchange.getOfferedWear().setStatus(WearStatus.AVAILABLE);
+        return exchangeMapper.toGetExchange(exchangeRepository.save(exchange));
+    }
+
+    @Override
+    public List<GetExchange> getAllExchanges() {
+        return exchangeRepository.findAll().stream().map(exchangeMapper::toGetExchange).collect(Collectors.toList());
+    }
+
+}

--- a/src/main/resources/db/migration/dev/V3__create_exchange.sql
+++ b/src/main/resources/db/migration/dev/V3__create_exchange.sql
@@ -1,0 +1,17 @@
+CREATE TABLE exchange (
+                          id BIGINT AUTO_INCREMENT PRIMARY KEY,
+                          requester_id BIGINT NOT NULL,
+                          owner_id BIGINT NOT NULL,
+                          offered_wear_id BIGINT NOT NULL,
+                          requested_wear_id BIGINT NOT NULL,
+                          status VARCHAR(20) NOT NULL DEFAULT 'PENDING',
+                          requester_confirmed BOOLEAN NOT NULL DEFAULT FALSE,
+                          owner_confirmed BOOLEAN NOT NULL DEFAULT FALSE,
+                          created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                          updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+
+                          CONSTRAINT fk_exchange_requester FOREIGN KEY (requester_id) REFERENCES users(id),
+                          CONSTRAINT fk_exchange_owner FOREIGN KEY (owner_id) REFERENCES users(id),
+                          CONSTRAINT fk_exchange_offered_wear FOREIGN KEY (offered_wear_id) REFERENCES wears(id),
+                          CONSTRAINT fk_exchange_requested_wear FOREIGN KEY (requested_wear_id) REFERENCES wears(id)
+);

--- a/src/main/resources/db/migration/prod/V3__create_exchange.sql
+++ b/src/main/resources/db/migration/prod/V3__create_exchange.sql
@@ -1,0 +1,17 @@
+CREATE TABLE exchange (
+                          id BIGINT IDENTITY(1,1) PRIMARY KEY,
+                          requester_id BIGINT NOT NULL,
+                          owner_id BIGINT NOT NULL,
+                          offered_wear_id BIGINT NOT NULL,
+                          requested_wear_id BIGINT NOT NULL,
+                          status VARCHAR(20) NOT NULL DEFAULT 'PENDING',
+                          requester_confirmed BIT NOT NULL DEFAULT 0,
+                          owner_confirmed BIT NOT NULL DEFAULT 0,
+                          created_at DATETIME2 DEFAULT SYSUTCDATETIME(),
+                          updated_at DATETIME2 DEFAULT SYSUTCDATETIME(),
+
+                          CONSTRAINT fk_exchange_requester FOREIGN KEY (requester_id) REFERENCES users(id),
+                          CONSTRAINT fk_exchange_owner FOREIGN KEY (owner_id) REFERENCES users(id),
+                          CONSTRAINT fk_exchange_offered_wear FOREIGN KEY (offered_wear_id) REFERENCES wears(id),
+                          CONSTRAINT fk_exchange_requested_wear FOREIGN KEY (requested_wear_id) REFERENCES wears(id)
+);


### PR DESCRIPTION
Este PR introduce la capa de control para el módulo de intercambios, permitiendo gestionar el ciclo completo de un intercambio entre usuarios.
Se incluye la integración con la lógica de negocio ya definida en ExchangeServiceImpl.